### PR TITLE
CHAIN-1547: Set ENABLE_COMPRESSION flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,10 +34,11 @@ func main() {
 	}
 
 	duneClient, err := duneapi.New(logger, duneapi.Config{
-		APIKey:         cfg.Dune.APIKey,
-		URL:            cfg.Dune.URL,
-		BlockchainName: cfg.BlockchainName,
-		Stack:          cfg.RPCStack,
+		APIKey:             cfg.Dune.APIKey,
+		URL:                cfg.Dune.URL,
+		BlockchainName:     cfg.BlockchainName,
+		Stack:              cfg.RPCStack,
+		DisableCompression: !cfg.EnableCompression,
 	})
 	if err != nil {
 		stdlog.Fatal(err)

--- a/config/config.go
+++ b/config/config.go
@@ -32,12 +32,13 @@ func (r RPCClient) HasError() error {
 }
 
 type Config struct {
-	BlockHeight    int64  `long:"block-height" env:"BLOCK_HEIGHT" description:"block height to start from" default:"-1"`      // nolint:lll
-	BlockchainName string `long:"blockchain-name" env:"BLOCKCHAIN_NAME" description:"name of the blockchain" required:"true"` // nolint:lll
-	Dune           DuneClient
-	PollInterval   time.Duration `long:"rpc-poll-interval" env:"RPC_POLL_INTERVAL" description:"Interval to poll the blockchain node" default:"500ms"` // nolint:lll
-	RPCNode        RPCClient
-	RPCStack       models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"` // nolint:lll
+	BlockHeight       int64  `long:"block-height" env:"BLOCK_HEIGHT" description:"block height to start from" default:"-1"`                     // nolint:lll
+	BlockchainName    string `long:"blockchain-name" env:"BLOCKCHAIN_NAME" description:"name of the blockchain" required:"true"`                // nolint:lll
+	EnableCompression bool   `long:"enable-compression" env:"ENABLE_COMPRESSION" description:"enable compression when pushing payload to Dune"` // nolint:lll
+	Dune              DuneClient
+	PollInterval      time.Duration `long:"rpc-poll-interval" env:"RPC_POLL_INTERVAL" description:"Interval to poll the blockchain node" default:"500ms"` // nolint:lll
+	RPCNode           RPCClient
+	RPCStack          models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"` // nolint:lll
 }
 
 func (c Config) HasError() error {


### PR DESCRIPTION
When running we default to compression payload, using `application/zstd`. We get back:
`{"error":"Invalid content type 'application/zstd'. We support CSV (Content-Type: text/csv) and newline delimited JSON (Content-Type: application/x-ndjson"}`

We customize the behavior using `ENABLE_COMPRESSION=false` flag.