### PR TITLE
Resume with blockchain progress endpoints

### DIFF
--- a/client/duneapi/client.go
+++ b/client/duneapi/client.go
@@ -184,17 +184,22 @@ func (c *client) PostProgressReport(ctx context.Context, progress models.Blockch
 		} else {
 			c.log.Info("Sent progress report",
 				"lastIngestedBlockNumer", request.LastIngestedBlockNumber,
+				"latestBlockNumber", request.LatestBlockNumber,
 				"duration", time.Since(start),
 			)
 		}
 	}()
 
+	request = BlockchainProgress{
+		LastIngestedBlockNumber: progress.LastIngestedBlockNumber,
+		LatestBlockNumber:       progress.LatestBlockNumber,
+	}
 	url := fmt.Sprintf("%s/api/beta/blockchain/%s/ingest/progress", c.cfg.URL, c.cfg.BlockchainName)
-	c.log.Debug("Sending request", "url", url)
-	payload, err := json.Marshal(progress)
+	payload, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
+	c.log.Info("Sending request", "url", url, "payload", string(payload))
 	req, err := retryablehttp.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
 	if err != nil {
 		return err

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -12,12 +12,12 @@ import (
 
 type Ingester interface {
 	// Run starts the ingester and blocks until the context is cancelled or maxCount blocks are ingested
-	Run(ctx context.Context, startBlockNumber, maxCount int64) error
+	Run(ctx context.Context, startBlockNumber int64, maxCount int64) error
 
 	// ConsumeBlocks sends blocks from startBlockNumber to endBlockNumber to outChan, inclusive.
 	// If endBlockNumber is -1, it sends blocks from startBlockNumber to the tip of the chain
 	// it will run continuously until the context is cancelled
-	ConsumeBlocks(ctx context.Context, outChan chan models.RPCBlock, startBlockNumber, endBlockNumber int64) error
+	ConsumeBlocks(ctx context.Context, outChan chan models.RPCBlock, startBlockNumber int64, endBlockNumber int64) error
 
 	// SendBlocks pushes to DuneAPI the RPCBlock Payloads as they are received in an endless loop
 	// it will block until:
@@ -28,6 +28,8 @@ type Ingester interface {
 
 	// This is just a placeholder for now
 	Info() Info
+
+	Close() error
 }
 
 const (


### PR DESCRIPTION
This PR adds use of the GetBlockchainProgress endpoint on startup, and continuous calls to PostProgressEndpoint to update the progress.

Try with

```
export DUNE_API_KEY=<dune team api key in dev>
go run cmd/main.go --blockchain-name byob --dune-api-url "https://api.dev.dune.com" --rpc-node-url "https://sepolia.rpc.zora.energy"
```

Towards CHAIN-1588.