### PR TITLE
Some improvements in mainloop.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,8 +39,8 @@ type Config struct {
 	PollInterval           time.Duration `long:"rpc-poll-interval" env:"RPC_POLL_INTERVAL" description:"Interval to poll the blockchain node" default:"300ms"`    // nolint:lll
 	ReportProgressInterval time.Duration `long:"report-progress-interval" env:"REPORT_PROGRESS_INTERVAL" description:"Interval to report progress" default:"30s"` // nolint:lll
 	RPCNode                RPCClient
-	RPCStack               models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"` // nolint:lll
-	Concurrency            int             `long:"concurrency" env:"CONCURRENCY" description:"Number of concurrent workers"`           // nolint:lll
+	RPCStack               models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"`   // nolint:lll
+	Concurrency            int             `long:"concurrency" env:"CONCURRENCY" description:"Number of concurrent workers" default:"5"` // nolint:lll
 }
 
 func (c Config) HasError() error {

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -19,10 +19,10 @@ type Ingester interface {
 	// it will run continuously until the context is cancelled
 	ProduceBlockNumbers(ctx context.Context, outChan chan int64, startBlockNumber int64, endBlockNumber int64) error
 
-	// ConsumeBlocks fetches blocks sent on the channel and sends them on the other channel.
+	// FetchBlockLoop fetches blocks sent on the channel and sends them on the other channel.
 	// It will run continuously until the context is cancelled, or the channel is closed.
 	// It can safely be run concurrently.
-	ConsumeBlocks(context.Context, chan int64, chan models.RPCBlock) error
+	FetchBlockLoop(context.Context, chan int64, chan models.RPCBlock) error
 
 	// SendBlocks pushes to DuneAPI the RPCBlock Payloads as they are received in an endless loop
 	// it will block until:
@@ -83,9 +83,6 @@ func New(log *slog.Logger, node jsonrpc.BlockchainClient, dune duneapi.Blockchai
 			RPCErrors:  []ErrorInfo{},
 			DuneErrors: []ErrorInfo{},
 		},
-	}
-	if ing.cfg.MaxBatchSize == 0 {
-		ing.cfg.MaxBatchSize = defaultMaxBatchSize
 	}
 	if ing.cfg.PollInterval == 0 {
 		ing.cfg.PollInterval = defaultPollInterval

--- a/ingester/mainloop_test.go
+++ b/ingester/mainloop_test.go
@@ -149,19 +149,17 @@ func TestSendBlocks(t *testing.T) {
 	require.Equal(t, int64(5), sentBlockNumber)
 }
 
-// TestRunLoopUntilBlocksOutOfOrder asserts that we can fetch blocks concurrently and that we ingest them in order
+// TestRunLoopBlocksOutOfOrder asserts that we can fetch blocks concurrently and that we ingest them in order
 // even if they are produced out of order. We ensure they are produced out of order by sleeping a random amount of time.
-func TestRunLoopUntilBlocksOutOfOrder(t *testing.T) {
+func TestRunLoopBlocksOutOfOrder(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	maxBlockNumber := int64(1000)
 	sentBlockNumber := int64(0)
 	producedBlockNumber := int64(0)
 	duneapi := &duneapi_mock.BlockchainIngesterMock{
 		SendBlockFunc: func(_ context.Context, block models.RPCBlock) error {
-			// DuneAPI must fail if it receives blocks out of order
-			if block.BlockNumber != sentBlockNumber+1 {
-				return errors.Errorf("blocks out of order")
-			}
+			// Test must fail if DuneAPI receives blocks out of order
+			require.Equal(t, block.BlockNumber, sentBlockNumber+1)
 
 			atomic.StoreInt64(&sentBlockNumber, block.BlockNumber)
 			if block.BlockNumber == maxBlockNumber {


### PR DESCRIPTION
Implements some useful suggestion from @msf https://github.com/duneanalytics/node-indexer/pull/32
- `ConsumeBlocks` -> `FetchBlockLoop`
- Extract `trySendCompletedBlocks` from `SendBlocks`