### PR TITLE
Send a batch of blocks

### DIFF
--- a/client/duneapi/models.go
+++ b/client/duneapi/models.go
@@ -24,7 +24,8 @@ type Config struct {
 }
 
 type BlockchainIngestResponse struct {
-	Tables []IngestedTableInfo `json:"tables"`
+	Error  string              `json:"error,omitempty"`
+	Tables []IngestedTableInfo `json:"tables,omitempty"`
 }
 
 type IngestedTableInfo struct {
@@ -49,11 +50,13 @@ func (b *BlockchainIngestResponse) String() string {
 }
 
 type BlockchainIngestRequest struct {
-	BlockNumber     int64
-	ContentEncoding string
-	EVMStack        string
-	IdempotencyKey  string
-	Payload         []byte
+	FirstBlockNumber int64
+	LastBlockNumber  int64
+	BlockNumbers     []string
+	ContentEncoding  string
+	EVMStack         string
+	IdempotencyKey   string
+	Payload          []byte
 }
 
 type BlockchainProgress struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,7 @@ func main() {
 			PollInterval:           cfg.PollInterval,
 			Stack:                  cfg.RPCStack,
 			BlockchainName:         cfg.BlockchainName,
+			BatchRequestInterval:   cfg.BatchRequestInterval,
 		},
 	)
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,8 +39,9 @@ type Config struct {
 	PollInterval           time.Duration `long:"rpc-poll-interval" env:"RPC_POLL_INTERVAL" description:"Interval to poll the blockchain node" default:"300ms"`    // nolint:lll
 	ReportProgressInterval time.Duration `long:"report-progress-interval" env:"REPORT_PROGRESS_INTERVAL" description:"Interval to report progress" default:"30s"` // nolint:lll
 	RPCNode                RPCClient
-	RPCStack               models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"`   // nolint:lll
-	Concurrency            int             `long:"concurrency" env:"CONCURRENCY" description:"Number of concurrent workers" default:"5"` // nolint:lll
+	RPCStack               models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"`                                              // nolint:lll
+	Concurrency            int             `long:"concurrency" env:"CONCURRENCY" description:"Number of concurrent workers" default:"5"`                                            // nolint:lll
+	BatchRequestInterval   time.Duration   `long:"batch-request-interval" env:"BATCH_REQUEST_INTERVAL" description:"Interval at which to send batch requests to Dune" default:"1s"` // nolint:lll
 }
 
 func (c Config) HasError() error {

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -41,6 +41,7 @@ const (
 	defaultMaxBatchSize           = 5
 	defaultPollInterval           = 1 * time.Second
 	defaultReportProgressInterval = 30 * time.Second
+	defaultBatchRequestInterval   = 1 * time.Second
 )
 
 type Config struct {
@@ -49,6 +50,7 @@ type Config struct {
 	ReportProgressInterval time.Duration
 	Stack                  models.EVMStack
 	BlockchainName         string
+	BatchRequestInterval   time.Duration
 }
 
 type Info struct {


### PR DESCRIPTION
This PR changes the node indexer from sending one block at a time to sending a batch of blocks. Earlier we implemented concurrent block fetching with buffering (#32). On a configurable interval (defaults to every second), we now check the buffer and send all possible blocks.

This is still a WIP and probably should be split into two PRs
1. Batch requests on the DuneAPI client
2. Batch requests in the Ingester

We cannot use/merge this until we have support for batch requests on the API.