### PR TITLE
Dune client: SendBlock -> SendBlocks

### DIFF
--- a/client/duneapi/models.go
+++ b/client/duneapi/models.go
@@ -23,6 +23,7 @@ type Config struct {
 	DisableCompression bool
 }
 
+// The response from the DuneAPI ingest endpoint.
 type BlockchainIngestResponse struct {
 	Tables []IngestedTableInfo `json:"tables"`
 }
@@ -49,7 +50,8 @@ func (b *BlockchainIngestResponse) String() string {
 }
 
 type BlockchainIngestRequest struct {
-	BlockNumber     int64
+	BlockNumbers    string
+	BatchSize       int // number of blocks in the batch
 	ContentEncoding string
 	EVMStack        string
 	IdempotencyKey  string
@@ -57,14 +59,10 @@ type BlockchainIngestRequest struct {
 }
 
 type BlockchainProgress struct {
-	LastIngestedBlockNumber int64 `json:"last_ingested_block_number"`
-	LatestBlockNumber       int64 `json:"latest_block_number"`
+	LastIngestedBlockNumber int64 `json:"last_ingested_block_number,omitempty"`
+	LatestBlockNumber       int64 `json:"latest_block_number,omitempty"`
 }
 
 func (p *BlockchainProgress) String() string {
 	return fmt.Sprintf("%+v", *p)
-}
-
-type errorResponse struct {
-	Error string `json:"error"`
 }

--- a/ingester/mainloop.go
+++ b/ingester/mainloop.go
@@ -196,7 +196,7 @@ func (i *ingester) trySendCompletedBlocks(
 ) int64 {
 	// Send this block only if we have sent all previous blocks
 	for block, ok := blocks[nextNumberToSend]; ok; block, ok = blocks[nextNumberToSend] {
-		if err := i.dune.SendBlock(ctx, block); err != nil {
+		if err := i.dune.SendBlocks(ctx, []models.RPCBlock{block}); err != nil {
 			if errors.Is(err, context.Canceled) {
 				i.log.Info("SendBlocks: Context canceled, stopping")
 				return nextNumberToSend

--- a/ingester/mainloop_test.go
+++ b/ingester/mainloop_test.go
@@ -25,7 +25,12 @@ func TestRunLoopUntilCancel(t *testing.T) {
 	sentBlockNumber := int64(0)
 	producedBlockNumber := int64(0)
 	duneapi := &duneapi_mock.BlockchainIngesterMock{
-		SendBlockFunc: func(_ context.Context, block models.RPCBlock) error {
+		SendBlocksFunc: func(_ context.Context, blocks []models.RPCBlock) error {
+			if len(blocks) != 1 {
+				panic("expected 1 block")
+			}
+			block := blocks[0]
+
 			atomic.StoreInt64(&sentBlockNumber, block.BlockNumber)
 			if block.BlockNumber == maxBlockNumber {
 				// cancel execution when we send the last block
@@ -68,7 +73,7 @@ func TestRunLoopUntilCancel(t *testing.T) {
 
 func TestProduceBlockNumbers(t *testing.T) {
 	duneapi := &duneapi_mock.BlockchainIngesterMock{
-		SendBlockFunc: func(_ context.Context, _ models.RPCBlock) error {
+		SendBlocksFunc: func(_ context.Context, _ []models.RPCBlock) error {
 			return nil
 		},
 		PostProgressReportFunc: func(_ context.Context, _ models.BlockchainIndexProgress) error {
@@ -107,7 +112,12 @@ func TestProduceBlockNumbers(t *testing.T) {
 func TestSendBlocks(t *testing.T) {
 	sentBlockNumber := int64(0)
 	duneapi := &duneapi_mock.BlockchainIngesterMock{
-		SendBlockFunc: func(_ context.Context, block models.RPCBlock) error {
+		SendBlocksFunc: func(_ context.Context, blocks []models.RPCBlock) error {
+			if len(blocks) != 1 {
+				panic("expected 1 block")
+			}
+			block := blocks[0]
+
 			// DuneAPI must fail if it receives blocks out of order
 			if block.BlockNumber != sentBlockNumber+1 {
 				return errors.Errorf("blocks out of order")
@@ -157,7 +167,12 @@ func TestRunLoopBlocksOutOfOrder(t *testing.T) {
 	sentBlockNumber := int64(0)
 	producedBlockNumber := int64(0)
 	duneapi := &duneapi_mock.BlockchainIngesterMock{
-		SendBlockFunc: func(_ context.Context, block models.RPCBlock) error {
+		SendBlocksFunc: func(_ context.Context, blocks []models.RPCBlock) error {
+			if len(blocks) != 1 {
+				panic("expected 1 block")
+			}
+			block := blocks[0]
+
 			// Test must fail if DuneAPI receives blocks out of order
 			require.Equal(t, block.BlockNumber, sentBlockNumber+1)
 

--- a/mocks/duneapi/client.go
+++ b/mocks/duneapi/client.go
@@ -26,8 +26,8 @@ var _ duneapi.BlockchainIngester = &BlockchainIngesterMock{}
 //			PostProgressReportFunc: func(ctx context.Context, progress models.BlockchainIndexProgress) error {
 //				panic("mock out the PostProgressReport method")
 //			},
-//			SendBlockFunc: func(ctx context.Context, payload models.RPCBlock) error {
-//				panic("mock out the SendBlock method")
+//			SendBlocksFunc: func(ctx context.Context, payloads []models.RPCBlock) error {
+//				panic("mock out the SendBlocks method")
 //			},
 //		}
 //
@@ -42,8 +42,8 @@ type BlockchainIngesterMock struct {
 	// PostProgressReportFunc mocks the PostProgressReport method.
 	PostProgressReportFunc func(ctx context.Context, progress models.BlockchainIndexProgress) error
 
-	// SendBlockFunc mocks the SendBlock method.
-	SendBlockFunc func(ctx context.Context, payload models.RPCBlock) error
+	// SendBlocksFunc mocks the SendBlocks method.
+	SendBlocksFunc func(ctx context.Context, payloads []models.RPCBlock) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -59,17 +59,17 @@ type BlockchainIngesterMock struct {
 			// Progress is the progress argument value.
 			Progress models.BlockchainIndexProgress
 		}
-		// SendBlock holds details about calls to the SendBlock method.
-		SendBlock []struct {
+		// SendBlocks holds details about calls to the SendBlocks method.
+		SendBlocks []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Payload is the payload argument value.
-			Payload models.RPCBlock
+			// Payloads is the payloads argument value.
+			Payloads []models.RPCBlock
 		}
 	}
 	lockGetProgressReport  sync.RWMutex
 	lockPostProgressReport sync.RWMutex
-	lockSendBlock          sync.RWMutex
+	lockSendBlocks         sync.RWMutex
 }
 
 // GetProgressReport calls GetProgressReportFunc.
@@ -140,38 +140,38 @@ func (mock *BlockchainIngesterMock) PostProgressReportCalls() []struct {
 	return calls
 }
 
-// SendBlock calls SendBlockFunc.
-func (mock *BlockchainIngesterMock) SendBlock(ctx context.Context, payload models.RPCBlock) error {
-	if mock.SendBlockFunc == nil {
-		panic("BlockchainIngesterMock.SendBlockFunc: method is nil but BlockchainIngester.SendBlock was just called")
+// SendBlocks calls SendBlocksFunc.
+func (mock *BlockchainIngesterMock) SendBlocks(ctx context.Context, payloads []models.RPCBlock) error {
+	if mock.SendBlocksFunc == nil {
+		panic("BlockchainIngesterMock.SendBlocksFunc: method is nil but BlockchainIngester.SendBlocks was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		Payload models.RPCBlock
+		Ctx      context.Context
+		Payloads []models.RPCBlock
 	}{
-		Ctx:     ctx,
-		Payload: payload,
+		Ctx:      ctx,
+		Payloads: payloads,
 	}
-	mock.lockSendBlock.Lock()
-	mock.calls.SendBlock = append(mock.calls.SendBlock, callInfo)
-	mock.lockSendBlock.Unlock()
-	return mock.SendBlockFunc(ctx, payload)
+	mock.lockSendBlocks.Lock()
+	mock.calls.SendBlocks = append(mock.calls.SendBlocks, callInfo)
+	mock.lockSendBlocks.Unlock()
+	return mock.SendBlocksFunc(ctx, payloads)
 }
 
-// SendBlockCalls gets all the calls that were made to SendBlock.
+// SendBlocksCalls gets all the calls that were made to SendBlocks.
 // Check the length with:
 //
-//	len(mockedBlockchainIngester.SendBlockCalls())
-func (mock *BlockchainIngesterMock) SendBlockCalls() []struct {
-	Ctx     context.Context
-	Payload models.RPCBlock
+//	len(mockedBlockchainIngester.SendBlocksCalls())
+func (mock *BlockchainIngesterMock) SendBlocksCalls() []struct {
+	Ctx      context.Context
+	Payloads []models.RPCBlock
 } {
 	var calls []struct {
-		Ctx     context.Context
-		Payload models.RPCBlock
+		Ctx      context.Context
+		Payloads []models.RPCBlock
 	}
-	mock.lockSendBlock.RLock()
-	calls = mock.calls.SendBlock
-	mock.lockSendBlock.RUnlock()
+	mock.lockSendBlocks.RLock()
+	calls = mock.calls.SendBlocks
+	mock.lockSendBlocks.RUnlock()
 	return calls
 }


### PR DESCRIPTION
This PR changes the Dune client to send a batch of blocks. We still only send one block from the main loop, though.

See also previous draft PR https://github.com/duneanalytics/node-indexer/pull/36.