### PR TITLE
Send User-Agent header with commit hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Go workspace file
 go.work
 go.work.sum
+
+# Binary
+indexer

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ bin/gofumpt: bin
 	GOBIN=$(PWD)/bin go install mvdan.cc/gofumpt@v0.6.0
 
 build: cmd/main.go
-	CGO_ENABLED=0 go build -o indexer cmd/main.go
+	CGO_ENABLED=0 go build -ldflags="-X github.com/duneanalytics/blockchain-ingester/client/duneapi.commitHash=$(shell git rev-parse --short HEAD)" -o indexer cmd/main.go
 
 lint: bin/golangci-lint bin/gofumpt
 	go fmt ./...

--- a/client/duneapi/client.go
+++ b/client/duneapi/client.go
@@ -138,6 +138,12 @@ func (c *client) buildRequest(payloads []models.RPCBlock, buffer *bytes.Buffer) 
 	return request, nil
 }
 
+// We inject the commit hash here at build time, using the -X linker flag, so we can use it in the User-Agent header
+var (
+	commitHash string
+	userAgent  = fmt.Sprintf("node-indexer/%s", commitHash)
+)
+
 func (c *client) sendRequest(ctx context.Context, request BlockchainIngestRequest) error {
 	start := time.Now()
 	var err error
@@ -172,6 +178,7 @@ func (c *client) sendRequest(ctx context.Context, request BlockchainIngestReques
 		req.Header.Set("Content-Encoding", request.ContentEncoding)
 	}
 	req.Header.Set("Content-Type", "application/x-ndjson")
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("x-idempotency-key", request.IdempotencyKey)
 	req.Header.Set("x-dune-evm-stack", request.EVMStack)
 	req.Header.Set("x-dune-api-key", c.cfg.APIKey)


### PR DESCRIPTION
This PR adds a User-Agent header on the format `node-indexer/<hash>`. We try follow the convention described [on Wikipedia](https://en.wikipedia.org/wiki/User-Agent_header#:~:text=Mozilla/%5Bversion%5D%20(%5Bsystem%20and%20browser%20information%5D)%20%5Bplatform%5D%20(%5Bplatform%20details%5D)%20%5Bextensions%5D).

This will be very useful when debugging!

We inject the Git hash using option 1 from Adam's excellent resource https://developers.redhat.com/articles/2022/11/14/3-ways-embed-commit-hash-go-programs#1__using__ldflags. Option 3 doesn't work because even when building with `-buildvcs`, a `go build <file>` doesn't embed the VCS info, as tracked in this open issue: https://github.com/golang/go/issues/51279#issuecomment-1048196896

Have verified this locally using Docker build.