### PR TITLE
Add DLQ for reprocessing of failed blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # Binary
 indexer
+bin
+
+.idea

--- a/client/duneapi/models.go
+++ b/client/duneapi/models.go
@@ -83,3 +83,17 @@ type BlockchainError struct {
 	Error        string    `json:"error"`
 	Source       string    `json:"source"`
 }
+
+type BlockchainGapsResponse struct {
+	Gaps []BlockGap `json:"gaps"`
+}
+
+// BlockGap declares an inclusive range of missing block numbers
+type BlockGap struct {
+	FirstMissing int64 `json:"first_missing"`
+	LastMissing  int64 `json:"last_missing"`
+}
+
+func (b *BlockchainGapsResponse) String() string {
+	return fmt.Sprintf("%+v", *b)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -42,15 +42,20 @@ func (r RPCClient) HasError() error {
 }
 
 type Config struct {
-	BlockHeight            int64  `long:"block-height" env:"BLOCK_HEIGHT" description:"block height to start from" default:"-1"`                     // nolint:lll
-	BlockchainName         string `long:"blockchain-name" env:"BLOCKCHAIN_NAME" description:"name of the blockchain" required:"true"`                // nolint:lll
-	DisableCompression     bool   `long:"disable-compression" env:"DISABLE_COMPRESSION" description:"disable compression when sending data to Dune"` // nolint:lll
+	BlockHeight            int64  `long:"block-height" env:"BLOCK_HEIGHT" description:"block height to start from" default:"-1"`                         // nolint:lll
+	BlockchainName         string `long:"blockchain-name" env:"BLOCKCHAIN_NAME" description:"name of the blockchain" required:"true"`                    // nolint:lll
+	DisableCompression     bool   `long:"disable-compression" env:"DISABLE_COMPRESSION" description:"disable compression when sending data to Dune"`     // nolint:lll
+	DisableGapsQuery       bool   `long:"disable-gaps-query" env:"DISABLE_GAPS_QUERY" description:"disable gaps query used to populate the initial DLQ"` // nolint:lll
+	DLQOnly                bool   `long:"dlq-only" env:"DLQ_ONLY" description:"Runs just the DLQ processing on its own"`                                 // nolint:lll
 	Dune                   DuneClient
 	PollInterval           time.Duration `long:"rpc-poll-interval" env:"RPC_POLL_INTERVAL" description:"Interval to poll the blockchain node" default:"300ms"`    // nolint:lll
+	PollDLQInterval        time.Duration `long:"dlq-poll-interval" env:"DLQ_POLL_INTERVAL" description:"Interval to poll the dlq" default:"300ms"`                // nolint:lll
+	DLQRetryInterval       time.Duration `long:"dlq-retry-interval" env:"DLQ_RETRY_INTERVAL" description:"Interval for linear backoff in DLQ " default:"1m"`      // nolint:lll
 	ReportProgressInterval time.Duration `long:"report-progress-interval" env:"REPORT_PROGRESS_INTERVAL" description:"Interval to report progress" default:"30s"` // nolint:lll
 	RPCNode                RPCClient
 	RPCStack               models.EVMStack `long:"rpc-stack" env:"RPC_STACK" description:"Stack for the RPC client" default:"opstack"`                                                 // nolint:lll
 	RPCConcurrency         int             `long:"rpc-concurrency" env:"RPC_CONCURRENCY" description:"Number of concurrent requests to the RPC node" default:"25"`                     // nolint:lll
+	DLQConcurrency         int             `long:"dlq-concurrency" env:"DLQ_CONCURRENCY" description:"Number of concurrent requests to the RPC node for DLQ processing" default:"2"`   // nolint:lll
 	BlockSubmitInterval    time.Duration   `long:"block-submit-interval" env:"BLOCK_SUBMIT_INTERVAL" description:"Interval at which to submit batched blocks to Dune" default:"500ms"` // nolint:lll
 	LogLevel               string          `long:"log" env:"LOG" description:"Log level" choice:"info" choice:"debug" choice:"warn" choice:"error" default:"info"`                     // nolint:lll
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/duneanalytics/blockchain-ingester
 go 1.22.2
 
 require (
+	github.com/emirpasic/gods v1.18.1
 	github.com/go-errors/errors v1.5.1
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/jessevdk/go-flags v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=

--- a/lib/dlq/dlq.go
+++ b/lib/dlq/dlq.go
@@ -1,0 +1,94 @@
+package dlq
+
+import (
+	"sync"
+	"time"
+
+	pq "github.com/emirpasic/gods/queues/priorityqueue"
+	"github.com/emirpasic/gods/utils"
+)
+
+type DLQ[T any] struct {
+	priorityQueue pq.Queue // structure not thread safe
+	mutex         sync.Mutex
+	retryDelay    RetryStrategy
+}
+
+// RetryStrategy takes the number of retries and returns a Duration.
+// This allows the caller to implement any strategy they like, be it constant, linear, exponential, etc.
+type RetryStrategy func(retries int) time.Duration
+
+// Item This is generic so that metadata about retries can be maintained in an envelope during processing for when
+// an item needs to make its way back onto the DLQ later
+type Item[T any] struct {
+	Value       T
+	Retries     int
+	nextRunTime time.Time
+}
+
+func MapItem[T, U any](b Item[T], mapper func(T) U) Item[U] {
+	return Item[U]{
+		Value:       mapper(b.Value),
+		Retries:     b.Retries,
+		nextRunTime: b.nextRunTime,
+	}
+}
+
+func NewDLQ[T any]() *DLQ[T] {
+	return NewDLQWithDelay[T](RetryDelayLinear(time.Minute))
+}
+
+func RetryDelayLinear(backoff time.Duration) RetryStrategy {
+	return func(retries int) time.Duration {
+		return time.Duration(retries) * backoff // retries must be converted to a Duration for multiplication
+	}
+}
+
+func NewDLQWithDelay[T any](retryDelay func(retries int) time.Duration) *DLQ[T] {
+	return &DLQ[T]{priorityQueue: *pq.NewWith(byNextRunTime[T]), retryDelay: retryDelay}
+}
+
+// Comparator function (sort by nextRunTime in ascending order)
+func byNextRunTime[T any](a, b interface{}) int {
+	return utils.TimeComparator(a.(Item[T]).nextRunTime, b.(Item[T]).nextRunTime)
+}
+
+func (dlq *DLQ[T]) AddItem(item T, retries int) {
+	nextRunTime := time.Now().Add(dlq.retryDelay(retries))
+
+	dlq.mutex.Lock()
+	defer dlq.mutex.Unlock()
+
+	dlq.priorityQueue.Enqueue(Item[T]{Value: item, Retries: retries + 1, nextRunTime: nextRunTime})
+}
+
+func (dlq *DLQ[T]) AddItemHighPriority(item T) {
+	dlq.mutex.Lock()
+	defer dlq.mutex.Unlock()
+
+	dlq.priorityQueue.Enqueue(Item[T]{Value: item, Retries: 0, nextRunTime: time.Time{}})
+}
+
+func (dlq *DLQ[T]) GetNextItem() (value *Item[T], ok bool) {
+	dlq.mutex.Lock()
+	defer dlq.mutex.Unlock()
+
+	peek, ok := dlq.priorityQueue.Peek()
+	if !ok || peek.(Item[T]).nextRunTime.After(time.Now()) {
+		return nil, false
+	}
+
+	item, ok := dlq.priorityQueue.Dequeue()
+	if ok {
+		itemCasted := item.(Item[T])
+		return &itemCasted, ok
+	}
+	return nil, ok
+}
+
+func (dlq *DLQ[T]) Size() int {
+	dlq.mutex.Lock()
+	defer dlq.mutex.Unlock()
+
+	return dlq.priorityQueue.Size()
+}

--- a/models/gaps.go
+++ b/models/gaps.go
@@ -1,0 +1,10 @@
+package models
+
+type BlockchainGaps struct {
+	Gaps []BlockGap
+}
+
+type BlockGap struct {
+	FirstMissing int64
+	LastMissing  int64
+}


### PR DESCRIPTION
Adds a DLQ for block gaps and failed blocks to be reprocessed as per internal design doc.

Incidental bug fixes:
- Fixes a memory leak in `collectedBlocks` that would have existed when `SkipFailedBlocks` was enabled
- Makes an assertion conditional so it only works when we aren't skipping failed blocks. If we skip the last block that would have gone into a batch then we were panicking.
- Fixes a rare hang during an attempted clean shutdown if the context closes when we are writing to the channel