### PR TITLE
jsonrpc: small refactor, extract method for groupedJSON-RPC calls.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ bin:
 bin/moq: bin
 	GOBIN=$(PWD)/bin go install github.com/matryer/moq@v0.3.4
 bin/golangci-lint: bin
-	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 bin/gofumpt: bin
 	GOBIN=$(PWD)/bin go install mvdan.cc/gofumpt@v0.6.0
 


### PR DESCRIPTION
this is a small improvment to the current ugly code we use for:
- grouping error handling of rpc calls for the same block
- abiding to a maximum concurrency limit for the whole RPC node.

This is ontop of #70, 