### PR TITLE
Remove dependency install step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,11 +33,6 @@ jobs:
         with:
           registry-type: public
 
-      - name: Install prerequisites for Docker build
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
       - name: Build and push Docker images
         env:
           DOCKER_HUB_KEY: ${{ secrets.DOCKER_HUB_KEY }}


### PR DESCRIPTION
This package is now bundled in the base github runner, and we've removed `apt-get` from the image to prevent mistakes.